### PR TITLE
Bump ubuntu from `adbb901` to `58b8789`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy@sha256:adbb90115a21969d2fe6fa7f9af4253e16d45f8d4c1e930182610c4731962658
+FROM ubuntu:jammy@sha256:58b87898e82351c6cf9cf5b9f3c20257bb9e2dcf33af051e12ce532d7f94e3fe
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Bumps ubuntu from `adbb901` to `58b8789`.

---
updated-dependencies:
- dependency-name: ubuntu dependency-type: direct:production ...